### PR TITLE
feat: add string padding to time format

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import {
   ScheduleResponse,
 } from "./model/pray.model";
 import { PrayName } from "./constant/pray.constant";
-import { calculateCownDown, getTomorrowDate } from "./utils/time";
+import { calculateCountdown, getTomorrowDate } from "./utils/time";
 import { showFullScreenAlert } from "./utils/alert";
 import {
   getCityID,
@@ -158,7 +158,7 @@ export function activate(context: vscode.ExtensionContext) {
                 getSholatTime(today)
               );
             } else {
-              const cdTime = calculateCownDown(selisihWaktu);
+              const cdTime = calculateCountdown(selisihWaktu);
               const lokasiLabel = getIsShowCityName(context)
                 ? ` [${lokasi}]`
                 : "";
@@ -192,7 +192,7 @@ export function activate(context: vscode.ExtensionContext) {
                 () => getSholatTime(today)
               );
             } else {
-              const cdTime = calculateCownDown(selisihWaktu);
+              const cdTime = calculateCountdown(selisihWaktu);
               const lokasiLabel = getIsShowCityName(context)
                 ? ` [${lokasi}]`
                 : "";

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,13 +1,20 @@
 type CountDownTime = {
-  hours: number;
-  minutes: number;
-  seconds: number;
+  hours: string;
+  minutes: string;
+  seconds: string;
 };
 
-export function calculateCownDown(selisihWaktu: number): CountDownTime {
-  const hours = Math.floor((selisihWaktu / (1000 * 60 * 60)) % 24);
-  const minutes = Math.floor((selisihWaktu / (1000 * 60)) % 60);
-  const seconds = Math.floor((selisihWaktu / 1000) % 60);
+export function calculateCountdown(selisihWaktu: number): CountDownTime {
+  const hours = Math.floor((selisihWaktu / (1000 * 60 * 60)) % 24)
+    .toString()
+    .padStart(2, "0");
+  const minutes = Math.floor((selisihWaktu / (1000 * 60)) % 60)
+    .toString()
+    .padStart(2, "0");
+  const seconds = Math.floor((selisihWaktu / 1000) % 60)
+    .toString()
+    .padStart(2, "0");
+
   return {
     hours,
     minutes,


### PR DESCRIPTION
In this PR, I changed the function name `calculateCownDown` to `calculateCountdown`. Additionally, I also added `.padStart(2, "0")` to the new `calculateCountdown` function.

This will resolve #10 which is to add extra `"0"` if the time value is one digit.