### PR TITLE
fix: extensions stop working when panel disposed via close tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.1.1] - 2023-11-22
+
+- **Fix: Extensions stop working when panel disposed via close tab**
+
 ## [1.1.0] - 2023-11-15
 
 - **Support International Time**

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Sholat Reminder
 
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
-![Version](https://img.shields.io/badge/version-1.1.0-brightgreen.svg)
+![Version](https://img.shields.io/badge/version-1.1.1-brightgreen.svg)
 ![Maintained](https://img.shields.io/badge/maintained-yes-green.svg)
 ![Download](https://img.shields.io/visual-studio-marketplace/d/AdityaPutraPratama.sholat-reminder)
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "icon": "media/icon.png",
   "license": "SEE LICENSE IN LICENSE.md",
   "description": "",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Aditya Putra Pratama",
   "publisher": "AdityaPutraPratama",
   "engines": {

--- a/src/utils/alert.ts
+++ b/src/utils/alert.ts
@@ -85,9 +85,16 @@ export async function showFullScreenAlert(
     panel.webview.onDidReceiveMessage((message) => {
       if (message.command === "close") {
         panel.dispose();
-        callback();
       }
     })
+  );
+
+  panel.onDidDispose(
+    () => {
+      callback();
+    },
+    null,
+    context.subscriptions
   );
 }
 


### PR DESCRIPTION
move callback to function `panel.onDidDispose` so it catch action when user close panel via "tutup" button or close tab icon #28 