### PR TITLE
feat: reminder before pray feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
 - **Status Bar Reminder**: Menampilkan countdown menuju waktu sholat berikutnya di status bar.
 - **Full-Screen Notification**: Memberikan notifikasi layar penuh saat waktu sholat tiba.
 - **Automatic Reload**: Mereload ekstensi secara otomatis setelah City ID diperbarui.
+- **Set Reminder Before Pray**: Atur waktu pengingat sebelum waktu sholat tiba.
 
 ## Sumber API
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,10 @@
       {
         "command": "extension.refreshSholatSchedule",
         "title": "Sholat Reminder: Refresh"
+      },
+      {
+        "command": "extension.setReminderBeforePray",
+        "title": "Sholat Reminder: Set Reminder Before Pray"
       }
     ]
   },

--- a/src/commands/reminder.command.ts
+++ b/src/commands/reminder.command.ts
@@ -1,0 +1,25 @@
+import * as vscode from "vscode";
+import { getReminderBeforePray, setReminderBeforePray } from "../config/db";
+export async function setReminderBeforePrayCommand(
+  context: vscode.ExtensionContext
+) {
+  const result = await vscode.window.showInputBox({
+    prompt: "Set reminder minutes before prayer time (0 to disable)",
+    placeHolder: "Enter minutes (e.g. 10)",
+    value: getReminderBeforePray(context).toString(),
+  });
+
+  if (result !== undefined) {
+    const minutes = parseInt(result);
+    if (isNaN(minutes) || minutes < 0) {
+      vscode.window.showErrorMessage(
+        "Please enter a valid number of minutes (0 or greater)"
+      );
+      return;
+    }
+    setReminderBeforePray(context, minutes);
+    vscode.window.showInformationMessage(
+      `Prayer reminder set to ${minutes} minutes before prayer time`
+    );
+  }
+}

--- a/src/config/db.ts
+++ b/src/config/db.ts
@@ -94,3 +94,16 @@ export function getCityState(
 ): CityState | undefined {
   return context.globalState.get<State>("state");
 }
+
+export function getReminderBeforePray(
+  context: vscode.ExtensionContext
+): number {
+  return context.globalState.get("reminderMinutes", 0); // default to 0 (no reminder)
+}
+
+export function setReminderBeforePray(
+  context: vscode.ExtensionContext,
+  minutes: number
+) {
+  context.globalState.update("reminderMinutes", minutes);
+}

--- a/src/constant/command.constant.ts
+++ b/src/constant/command.constant.ts
@@ -6,4 +6,5 @@ export const Command = {
   SEARCH_CITY: "extension.searchCity",
   TOGGLE_CITY_NAME: "extension.toogleCityName",
   REFRESH: "extension.refreshSholatSchedule",
+  SET_REMINDER_BEFORE_PRAY: "extension.setReminderBeforePray",
 };


### PR DESCRIPTION
### Reminder Before Prayer Time
- Set custom reminders before prayer times (e.g., 5, 10, or 15 minutes before)
- Get notified with enough time to prepare for prayer
- Helps ensure you never miss a prayer time
- Configurable through the command "Sholat Reminder: Set Reminder Before Pray"
- Default setting is 0 minutes (notifications only at prayer time)

How to use reminders:
1. Open Command Palette (Ctrl+Shift+P / Cmd+Shift+P)
2. Search for "Sholat Reminder: Set Reminder Before Pray"
3. Enter number of minutes you want to be reminded before prayer time
4. You'll receive notifications both at your set reminder time and when prayer time arrives

Purpose:
- Help Muslims prepare for prayer times in advance
- Ensure proper time management around prayer schedules
- Support maintaining regular prayer habits while working
- Provide gentle reminders without disrupting workflow