### PR TITLE
Fix: Error Syntax and Add Jum'at Label

### DIFF
--- a/src/constant/quote.constant.ts
+++ b/src/constant/quote.constant.ts
@@ -116,7 +116,7 @@ export const QuoteSholat: Quote[] = [
   {
     author: "HR. Tirmidzi",
     content: `Rasulullah shallallahu ‘alaihi wasallam bersabda, “Pokok dari perkara adalah Islam, tiangnya adalah salat, dan puncaknya adalah jihad.”
-    Referensi : https://muslim.or.id/100935-salat-adalah-ibadah-yang-agung-yakin-masih-mau-meninggalkannya.html`
+    Referensi : https://muslim.or.id/100935-salat-adalah-ibadah-yang-agung-yakin-masih-mau-meninggalkannya.html`,
     id: 0
   },
   {

--- a/src/utils/alert.ts
+++ b/src/utils/alert.ts
@@ -111,10 +111,12 @@ export async function showFullScreenAlert(
 export function generatePrayerTooltip(
   schedule: Schedule
 ): vscode.MarkdownString {
+  const isJumah = new Date().getDay() === 5;
+  const dzuhurTimeLabel = isJumah ? PrayName.Dzuhur + " (Jum'at)" : PrayName.Dzuhur;
   return new vscode.MarkdownString(
     `**Sholat**       **Waktu**  
      **${PrayName.Subuh}**:      ${schedule.subuh}  
-     **${PrayName.Dzuhur}**:     ${schedule.dzuhur}  
+     **${dzuhurTimeLabel}**:     ${schedule.dzuhur}  
      **${PrayName.Ashar}**:      ${schedule.ashar}  
      **${PrayName.Maghrib}**:    ${schedule.maghrib}  
      **${PrayName.Isya}**:       ${schedule.isya}`


### PR DESCRIPTION
**New Label for Jum'at Prayer**

**Purpose:**
1. Sometimes we are coding in the morning and forget that today is Jumat prayer time, so these changes will help us to remember and prepare for Jum'at prayer.

**Changes:**
1. Fix syntax error (Forgot one comma)
2. Add Label "**_Dzuhur (Jum'at)_**" on Friday.